### PR TITLE
Add options, refactor scenes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 dist
 dist-*
 .ghc.environment.*
+*.o
+*.hi

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ ghc:
   - "8.0.2"
 
 # We have no tests for now, so override the default script
-script: cabal configure --enable-tests && cabal build
+script: cabal configure --enable-tests && cabal build && cabal run ray-tracer -- -s 8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: haskell
 ghc:
   - "8.0.2"
+  - "8.6.1"
 
 # We have no tests for now, so override the default script
 script: cabal configure --enable-tests && cabal build && cabal run ray-tracer -- -s 8

--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,81 @@
+NOTICES
+=======
+
+This implementation is based off of Peter Shirley's ["Ray-Tracing in a
+Weekend"](https://drive.google.com/file/d/1_MZBMUSO25pg1gyeHa_D8WXu7r37CvC6).
+
+Tutorials used:
+
++ https://www.stackbuilders.com/tutorials/haskell/image-processing/
++ http://hackage.haskell.org/package/base-4.12.0.0/docs/System-Console-GetOpt.html#t:ArgDescr
+
+
+Third-party licenses
+--------------------
+
+This project makes use of the following third-party libraries:
+
+### Juicy.Pixels
+
+```
+Copyright (c)2011, Vincent Berthoux
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Vincent Berthoux nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+### repa
+
+```
+Copyright (c) 2001-2014, The Data Parallel Haskell Team
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+- The names of the copyright holders may not be used to endorse or promote
+  products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```

--- a/README.md
+++ b/README.md
@@ -15,5 +15,23 @@ To run the ray-tracer, use
 
     cabal new-run ray-tracer
 
+To pass options, place them after a `--`:
+
+    cabal new-run ray-tracer -- --samples 64
+
+To run in parallel on `j` cores, call with `+RTS -Nj`, where `j` is an integer:
+
+    cabal new-run ray-tracer -- +RTS -N4
+
+Note: if rendering through `ghci`, it is recommended that you compile the
+`Trace` module at least with `cd src && ghc -c -dynamic Trace.hs`.  This can
+improve runtimes substantially.
+
+
+Acknowledgements
+----------------
+
+See [NOTICES](NOTICES).
+
 
 [shirley]: https://drive.google.com/file/d/1_MZBMUSO25pg1gyeHa_D8WXu7r37CvC6

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ray-tracer
 ==========
 
+[![Build Status](https://travis-ci.com/enjmiah/ray-tracer.svg?branch=master)](https://travis-ci.com/enjmiah/ray-tracer)
+
 A path tracer written in Haskell, based on [Peter Shirley's notes][shirley].
 
 

--- a/ray-tracer.cabal
+++ b/ray-tracer.cabal
@@ -18,9 +18,9 @@ cabal-version:       >=1.10
 executable ray-tracer
   main-is:             Main.hs
   other-modules:       Trace, Scene
-  GHC-Options:         -Wall -Wno-name-shadowing -Wno-orphans -Odph -rtsopts -threaded -fno-liberate-case -optlo-O3
+  GHC-Options:         -Wall -Wno-name-shadowing -Wno-orphans -rtsopts -threaded -fno-liberate-case -fno-state-hack
   -- other-extensions:
-  build-depends:       base >=4.9 && <4.10,
+  build-depends:       base >=4.9,
                        filepath,
                        random,
                        JuicyPixels >=3.3.2,

--- a/ray-tracer.cabal
+++ b/ray-tracer.cabal
@@ -17,10 +17,10 @@ cabal-version:       >=1.10
 
 executable ray-tracer
   main-is:             Main.hs
-  other-modules:       Trace
+  other-modules:       Trace, Scene
+  GHC-Options:         -Wall -Wno-name-shadowing -Wno-orphans -Odph -rtsopts -threaded -fno-liberate-case -optlo-O3
   -- other-extensions:
   build-depends:       base >=4.9 && <4.10,
-                       array,
                        filepath,
                        random,
                        JuicyPixels >=3.3.2,

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -115,6 +115,15 @@ calcPixelAt cam world options (Z :. x :. y) =
     in (65534.99*(sqrt red), 65534.99*(sqrt green), 65534.99*(sqrt blue))
 
 
+-- | Given a range of integer inputs, return integer outputs that appear to be
+-- uncorrelated to the supplied inputs.  We use this function to generate
+-- "random" seeds.
+decorrelate :: Int -> Int
+decorrelate x =
+    -- very high-frequency sine works well here for producing "random-ness"
+    unsafeCoerce (sin (fromIntegral (20000000000 * x) :: Double))
+
+
 -- | Return an anti-aliased sample in linear colorspace.  The anti-aliased
 -- sample is calculated as the average of several random samples.
 aaSample :: Camera -> [Primitive] -> Int -> Int -> Options -> Vec3
@@ -123,8 +132,8 @@ aaSample cam world x y options =
         (nx, _) = size cam
         sumColor =
             sum [randSample cam world x y options
-                            (mkRNG (unsafeCoerce (sin (fromIntegral (20000000000 * (y*nx*ns + x*ns + s)) :: Double)) :: Int))
-                                  | s <- [1..ns]]
+                            (mkRNG (decorrelate (y*nx*ns + x*ns + s)))
+                            | s <- [1..ns]]
     in (1 / fromIntegral ns) .* sumColor
 
 

--- a/src/Scene.hs
+++ b/src/Scene.hs
@@ -1,0 +1,92 @@
+module Scene
+( world
+, world1
+, world2
+, world3
+, skyColor1
+, skyColor2
+) where
+
+import Trace
+
+type World = (Camera, [Primitive])
+
+-- | List of primitives making up world, and also an interesting viewpoint
+world :: World
+world = world3
+
+
+-- | The color of the sky at the top of the world.
+skyColor1 :: Vec3
+skyColor1 = (0.5, 0.7, 1.0)
+
+
+-- | The color of the sky at the bottom of the world.
+skyColor2 :: Vec3
+skyColor2 = (1.0, 1.0, 1.0)
+
+
+----------------------------------------------------------------------------
+-- The following are several example scenes that can be rendered with the --
+-- ray-tracer.  Feel free to create your own.                             --
+----------------------------------------------------------------------------
+
+-- | This one is from Ch. 11 of Peter Shirley's book.  It is helpful in
+-- demonstrating depth of field.
+world1 :: World
+world1 =
+    (camera, [sphere1, sphere2, sphere3, ground])
+    where ground  = makeSphere (0.0,-100.5,-1.0) 100.0 (makeDiffuse (0.8, 0.8, 0.0))
+          sphere1 = makeSphere (0.0, 0.0, -1.0) 0.5 (makeDiffuse (0.1, 0.2, 0.5))
+          sphere2 = makeSphere (1.0, 0.0, -1.0) 0.5 (makeMetallic (0.8, 0.6, 0.2) 0.3)
+          sphere3 = makeSphere (-1.0, 0.0, -1.0) 0.5 (makeRefractive 1.5)
+          camera = makeCamera (3, 3, 2) (0, 0, -1) (0, 1, 0) 0.35 (200, 100) 2
+
+
+-- | Create several random spheres with random materials.
+randomScene :: RNG -> [Primitive]
+randomScene rng = fst (foldl randomObject ([], rng)
+                             [(a, b) | a <- [-5..4], b <- [-5..4]])
+
+-- | Create a random sphere with a random material.
+randomObject :: ([Primitive], RNG) -> (Double, Double) -> ([Primitive], RNG)
+randomObject (acc, rng) (basePosX, basePosZ) =
+    let (offsetX:offsetZ:newRng) = rng
+        center = (basePosX + 0.9 * offsetX, 0.2, basePosZ + 0.9 * offsetZ)
+        (material, newRng2) = randomMaterial newRng
+    in ((makeSphere center 0.2 material):acc, newRng2)
+
+-- | Choose a random material
+randomMaterial :: RNG -> (Material, RNG)
+randomMaterial rng
+    | random < 0.8  = (makeDiffuse (matRnd1 * matRnd2, matRnd3 * matRnd4,
+                                    matRnd5 * matRnd6),
+                       tl)
+    | random < 0.95 = (makeMetallic (0.5 .* ((1, 1, 1) + (matRnd1, matRnd2, matRnd3)))
+                                    (0.5 * matRnd4), tl)
+    | otherwise     = (makeRefractive 1.5, tl)
+    where (random:matRnd1:matRnd2:matRnd3:matRnd4:matRnd5:matRnd6:tl) = rng
+
+
+-- | Varied scene with lots of objects.  This scene is good for benchmarking.
+world2 :: World
+world2 =
+    (camera, [ground, sphere1, sphere2, sphere3] ++ randomScene (mkRNG 7))
+    where camera = makeCamera (13, 2, 3) (0, 0, 0) (0, 1, 0) 0.35 (300, 200) 0.2
+          ground = makeSphere (0, -1000, 0) 1000 (makeDiffuse (0.5, 0.5, 0.5))
+          sphere1 = makeSphere (0, 1, 0) 1 (makeRefractive 1.5)
+          sphere2 = makeSphere (-4, 1, 0) 1 (makeDiffuse (0.4, 0.2, 0.1))
+          sphere3 = makeSphere (4, 1, 0) 1 (makeMetallic (0.7, 0.6, 0.5) 0)
+
+
+-- | An interesting feature of our material system is that if we set the albedo
+-- color to be greater than 1 in at least one component, it will actually *emit*
+-- light.
+world3 :: World
+world3 =
+    (camera, [sphere1, sphere2, sphere3, ground])
+    where ground  = makeSphere (0.0,-100.5,-1.0) 100.0 (makeDiffuse (0.8, 0.8, 0.0))
+          sphere1 = makeSphere (0.0, 0.0, -1.0) 0.5 (makeDiffuse (16, 8, 0.5))
+          sphere2 = makeSphere (1.0, 0.0, -1.0) 0.5 (makeMetallic (0.8, 0.6, 0.2) 0.3)
+          sphere3 = makeSphere (-1.0, 0.0, -1.0) 0.5 (makeRefractive 1.5)
+          camera = makeCamera (3, 3, 2) (0, 0, -1) (0, 1, 0) 0.35 (200, 100) 0.01


### PR DESCRIPTION
I started on a scene file parser, but then I realized that it's going to be way too much work.  Instead I just refactored the code so that it can be called more easily using ghci.

I improved the random generation even more.  Now instead of generating seeds sequentially from the root process, I used a standard graphics hack of using a very high-frequency sine function to decorrelate the seeds.

I even managed to get some not terrible speedup when running in parallel:

```
$ time cabal new-run ray-tracer -- -s 64
Up to date
Options {samples = 64, maxBounces = 8, output = "out.png"}
cabal new-run ray-tracer -- -s 64  18.42s user 0.06s system 99% cpu 18.484 total
$ time cabal new-run ray-tracer -- -s 64 +RTS -N2
Up to date
Options {samples = 64, maxBounces = 8, output = "out.png"}
cabal new-run ray-tracer -- -s 64 +RTS -N2  20.51s user 0.41s system 196% cpu 10.653 total
```

Unfortunately, a lot of configurations will lead to a deadlock for some reason: 

    ray-tracer: thread blocked indefinitely in an MVar operation

I strongly suspect this is a bug in Repa but it could also be caused by an error in our code which will lead to a thread dying.

Anyways, here's some fun pictures:

![out3](https://user-images.githubusercontent.com/12449414/47066676-b31da280-d19b-11e8-9653-ec0e1ba1fa2c.png)
![out4](https://user-images.githubusercontent.com/12449414/47066687-b87aed00-d19b-11e8-9c53-e9d223afab54.png)


----------

@JGAJ can you do some testing and make sure that every function has documentation?  I think I got them all but maybe I missed one.