### PR TITLE
Remove `unsafeCoerce`s

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -12,7 +12,6 @@ import Data.Array.Repa (Z (..), (:.)(..))
 import System.Console.GetOpt
 import System.Environment (getArgs)
 import Text.Read
-import Unsafe.Coerce (unsafeCoerce)
 import qualified Data.Array.Repa as R
 
 import Scene (world, skyColor1, skyColor2)
@@ -121,7 +120,8 @@ calcPixelAt cam world options (Z :. x :. y) =
 decorrelate :: Int -> Int
 decorrelate x =
     -- very high-frequency sine works well here for producing "random-ness"
-    unsafeCoerce (sin (fromIntegral (20000000000 * x) :: Double))
+    floor (maxInt * (sin (fromIntegral (2000000000 * x) :: Double)))
+    where maxInt = fromIntegral (maxBound :: Int)
 
 
 -- | Return an anti-aliased sample in linear colorspace.  The anti-aliased

--- a/src/Trace.hs
+++ b/src/Trace.hs
@@ -4,9 +4,7 @@ Module for performing path tracing.
 
 module Trace where
 
-import Data.Int (Int64)
 import System.Random
-import Unsafe.Coerce (unsafeCoerce)
 
 
 ----------
@@ -277,9 +275,9 @@ type RNG = [Double]
 -- The interval being half-open is important, since it can avoid division by
 -- zero problems.
 mkRNG :: Int -> RNG
-mkRNG seed = randomRs (0.0, prevToOne) (mkStdGen seed)
-    where prevToOne :: Double -- largest Double < 1.0
-          prevToOne = unsafeCoerce (((unsafeCoerce (1 :: Double)) :: Int64) - 1)
+mkRNG seed = randomRs (0.0, oneMinusEpsilon) (mkStdGen seed)
+    where oneMinusEpsilon :: Double -- largest Double < 1.0
+          oneMinusEpsilon = 0.99999999999999989
 
 
 -- | Return a random vector inside a unit sphere.  The passed in RNG *must* be


### PR DESCRIPTION
Apparent doing an `unsafeCoerce` from `Double` to `Int` is [error-prone in practice](https://ghc.haskell.org/trac/ghc/ticket/2209).